### PR TITLE
build all with github actions

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,0 +1,58 @@
+name: build all, clean release and debug
+
+on:
+  push:
+
+jobs:
+  build_all:
+    strategy:
+      fail-fast: false
+      matrix:
+        spice: [RAMNV1, RAMNV1_CTF]
+        conf: [Release, Debug]
+    
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Build ECUB
+        uses: xanderhendriks/action-build-stm32cubeide@v7.0
+        with:
+          project-path: firmware/${{ matrix.spice }} -D TARGET_ECUB
+          project-target: ${{ matrix.spice}}/${{ matrix.conf}} -D TARGET_ECUB
+      - name: Copy ECUB hex
+        run: cp firmware/${{ matrix.spice }}/${{ matrix.conf }}/${{ matrix.spice }}.hex scripts/firmware/ECUB.hex
+
+      - name: Build ECUC
+        uses: xanderhendriks/action-build-stm32cubeide@v7.0
+        with:
+          project-path: firmware/${{ matrix.spice }} -D TARGET_ECUC
+          project-target: ${{ matrix.spice}}/${{ matrix.conf}} -D TARGET_ECUC
+      - name: Copy ECUC hex
+        run: cp firmware/${{ matrix.spice }}/${{ matrix.conf }}/${{ matrix.spice }}.hex scripts/firmware/ECUC.hex
+        
+      - name: Build ECUD
+        uses: xanderhendriks/action-build-stm32cubeide@v7.0
+        with:
+          project-path: firmware/${{ matrix.spice }} -D TARGET_ECUD
+          project-target: ${{ matrix.spice}}/${{ matrix.conf}} -D TARGET_ECUD
+      - name: Copy ECUD hex
+        run: cp firmware/${{ matrix.spice }}/${{ matrix.conf }}/${{ matrix.spice }}.hex scripts/firmware/ECUD.hex
+      
+      - name: Build ECUA
+        if: ${{ matrix.spice!='RAMNV1_CTF' }}
+        uses: xanderhendriks/action-build-stm32cubeide@v7.0
+        with:
+          project-path: firmware/${{ matrix.spice }} -D TARGET_ECUA
+          project-target: ${{ matrix.spice}}/${{ matrix.conf}} -D TARGET_ECUA
+      - name: Copy ECUA hex
+        if: ${{ matrix.spice!='RAMNV1_CTF' }}
+        run: cp firmware/${{ matrix.spice }}/${{ matrix.conf }}/${{ matrix.spice }}.hex scripts/firmware/ECUA.hex
+      
+
+      - name: upload RAMN dir as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.spice }}-${{ matrix.conf}}
+          path: .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ RAMN (Resistant Automotive Miniature Network) is a miniature CAN/CAN-FD testbed 
 
 Please check the [Documentation](https://ramn.readthedocs.io/) for demonstrations and details.
 
+[![build all, clean release and debug](https://github.com/ToyotaInfoTech/RAMN/actions/workflows/build_all.yml/badge.svg)](https://github.com/ToyotaInfoTech/RAMN/actions/workflows/build_all.yml)
+
 ## Project structure
 ### Hardware folder
 Contains design files, from KiCAD project files to gerber files and partial BOM (not including common components such as resistors and capacitors).


### PR DESCRIPTION
This PR introduces automated github actions for building RAMNV1 and RAMNV1_CTF both Release and Debug. The resulting RAMN dirs are uploaded as artifacts. ECUA is skipped in the RAMNV1_CTF variant.

This uses primarily xanderhendriks/action-build-stm32cubeide@v7.0 and the recipe in the BUILD_Clean_X.bat files

see it in action here https://github.com/BenGardiner/RAMN/actions
