### PR TITLE
enable automated builds on pull requests

### DIFF
--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -2,6 +2,7 @@ name: build all, clean release and debug
 
 on:
   push:
+  pull_request:
 
 jobs:
   build_all:


### PR DESCRIPTION
I noticed when submitting #10 that the automated builds I added were on `push` only which doesn't cause build checks on pull requests. This should fix that.