### PR TITLE
use script-relative paths in scripts/STBootloader/windows

### DIFF
--- a/scripts/STbootloader/windows/ProgramECU_A.bat
+++ b/scripts/STbootloader/windows/ProgramECU_A.bat
@@ -1,6 +1,7 @@
 @echo off
 
 SET RAMN_PORT=AUTO
+python "%~dp0\..\ECUA_goToDFU.py" %RAMN_PORT%
 
 SET STM32PROG_PATH="C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe"
 SET ECU_FIRMWARE_PATH=%~dp0\..\..\firmware\ECUA.hex

--- a/scripts/STbootloader/windows/ProgramECU_A.bat
+++ b/scripts/STbootloader/windows/ProgramECU_A.bat
@@ -3,8 +3,8 @@
 SET RAMN_PORT=AUTO
 
 SET STM32PROG_PATH="C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe"
-SET ECU_FIRMWARE_PATH=..\..\firmware\ECUA.hex
+SET ECU_FIRMWARE_PATH=%~dp0\..\..\firmware\ECUA.hex
 
-%STM32PROG_PATH% -c port=usb1 pid=0xdf11 vid=0x0483 -d %ECU_FIRMWARE_PATH% --verify --start 0x08000000 
+%STM32PROG_PATH% -c port=usb1 pid=0xdf11 vid=0x0483 -d "%ECU_FIRMWARE_PATH%" --verify --start 0x08000000
 
 timeout /t 10 > NUL

--- a/scripts/STbootloader/windows/ProgramECU_BCD.bat
+++ b/scripts/STbootloader/windows/ProgramECU_BCD.bat
@@ -2,10 +2,10 @@
 
 SET RAMN_PORT=AUTO
 
-SET ECU_FIRMWARE_PATH=..\..\firmware
+SET ECU_FIRMWARE_PATH=%~dp0\..\..\firmware
 
-python ..\canboot.py %RAMN_PORT% B -i %ECU_FIRMWARE_PATH%\ECUB.hex -e -p -v 
+python "%~dp0\..\canboot.py" %RAMN_PORT% B -i "%ECU_FIRMWARE_PATH%\ECUB.hex" -e -p -v
 
-python ..\canboot.py %RAMN_PORT% C -i %ECU_FIRMWARE_PATH%\ECUC.hex -e -p -v 
+python "%~dp0\..\canboot.py" %RAMN_PORT% C -i "%ECU_FIRMWARE_PATH%\ECUC.hex" -e -p -v
 
-python ..\canboot.py %RAMN_PORT% D -i %ECU_FIRMWARE_PATH%\ECUD.hex -e -p -v --reset
+python "%~dp0\..\canboot.py" %RAMN_PORT% D -i "%ECU_FIRMWARE_PATH%\ECUD.hex" -e -p -v --reset


### PR DESCRIPTION
using the script-relative paths makes these scripts invocable from anywhere

* also: call ECUA_goToDFU.py first in programming ECU A so the script works independently