### PR TITLE
OOB and Overflow Prevention

### DIFF
--- a/firmware/RAMNV1/Core/Src/main.c
+++ b/firmware/RAMNV1/Core/Src/main.c
@@ -1003,6 +1003,7 @@ void RAMN_ReceiveUSBFunc(void *argument)
 
 		xBytesReceived = xStreamBufferReceive(USBD_RxStreamBufferHandle, (void *)&commandLength, 2U, portMAX_DELAY );
 		if (xBytesReceived != 2U) Error_Handler();
+		if (commandLength > USB_COMMAND_BUFFER_SIZE) ErrorHandler();
 
 		xBytesReceived = xStreamBufferReceive(USBD_RxStreamBufferHandle, (void*)USBRxBuffer, commandLength,portMAX_DELAY);
 		if (xBytesReceived != commandLength) Error_Handler();

--- a/firmware/RAMNV1/Core/Src/ramn_chip8.c
+++ b/firmware/RAMNV1/Core/Src/ramn_chip8.c
@@ -406,7 +406,7 @@ uint8_t RAMN_CHIP8_Update(uint32_t xLastWakeTime)
 		case 0x2000:
 			stack[SP] = PC;
 			SP++;  // incrementing the SP
-			if (SP >= sizeof(stack))
+			if (SP >= (sizeof(stack)/sizeof(uint16_t)))
 			{
 				game_started = 0U;
 			}

--- a/firmware/RAMNV1/Core/Src/ramn_chip8.c
+++ b/firmware/RAMNV1/Core/Src/ramn_chip8.c
@@ -341,7 +341,7 @@ uint8_t RAMN_CHIP8_Update(uint32_t xLastWakeTime)
 			break;
 		case 0x00EE:
 			SP -= 1;
-			if (SP >= sizeof(stack)) //if an underflow happened, quit
+			if (SP >= (sizeof(stack)/sizeof(uint16_t))) //if an underflow happened, quit
 			{
 				game_started = 0U;
 			}


### PR DESCRIPTION
Fixed OOB in 2XXX CHIP-8 opcode + added check to ensure no overflow when reading data from the USB connection