### PR TITLE
Prevent memory OOB and off-by-one, setting memory size to 0x1000

### DIFF
--- a/firmware/RAMNV1/Core/Src/ramn_chip8.c
+++ b/firmware/RAMNV1/Core/Src/ramn_chip8.c
@@ -25,7 +25,7 @@
 0x200-0xFFF - Actual game memory
  */
 static uint16_t opcode; //Current opcode
-static uint8_t memory[0x1000+0x210]; //Interpreter memory
+static uint8_t memory[0x1000]; //Interpreter memory
 static uint8_t V[16]; //Sixteen working registers
 static uint8_t RPL[8]; //RPL registers (for super chip)
 static uint16_t I; //Memory pointer
@@ -688,12 +688,26 @@ uint8_t RAMN_CHIP8_Update(uint32_t xLastWakeTime)
 						PC += 2;
 						break;
 					case 0x0033:
+						// ensure we aren't reading outside of valid memory
+						if (I + 2 >= sizeof(memory))
+						{
+							game_started = 0U;
+							break;
+						}
+
 						memory[I] = V[(opcode & 0x0F00) >> 8] / 100;
 						memory[I + 1] = (V[(opcode & 0x0F00) >> 8] / 10) % 10;
 						memory[I + 2] = (V[(opcode & 0x0F00) >> 8] % 100) % 10;
 						PC += 2;
 						break;
 					case 0x0055:
+						// ensure we aren't reading outside of valid memory
+						if (I + ((opcode & 0x0F00) >> 8) >= sizeof(memory))
+						{
+							game_started = 0U;
+							break;
+						}
+
 						for (uint8_t i = 0; i <= ((opcode & 0x0F00) >> 8); i++)
 							memory[I + i] = V[i];
 						I += (1 + ((opcode & 0x0F00) >> 8));
@@ -701,6 +715,13 @@ uint8_t RAMN_CHIP8_Update(uint32_t xLastWakeTime)
 						break;
 
 					case 0x0065:
+						// ensure we aren't reading outside of valid memory
+						if (I + ((opcode & 0x0F00) >> 8) >= sizeof(memory))
+						{
+							game_started = 0U;
+							break;
+						}
+						
 						for (uint8_t i = 0; i <= ((opcode & 0x0F00) >> 8); i++)
 							V[i] = memory[I + i];
 						I += (1 + ((opcode & 0x0F00) >> 8));

--- a/firmware/RAMNV1/Core/Src/ramn_chip8.c
+++ b/firmware/RAMNV1/Core/Src/ramn_chip8.c
@@ -318,7 +318,7 @@ uint8_t RAMN_CHIP8_Update(uint32_t xLastWakeTime)
 		lastTimerUpdate = xLastWakeTime;
 	}
 
-	if (PC >= sizeof(memory) || (I >= sizeof(memory))) // PC or I overflow
+	if (PC >= (sizeof(memory)-1) || (I >= sizeof(memory))) // PC or I overflow
 	{
 		game_started = 0U;
 		return;


### PR DESCRIPTION
1. To ensure compliance with the CHIP-8 architecture, the memory size was decreased from 0x1210 to 0x1000. 

1. A possible off-by-one read is prevented by ensuring `PC < (memory-1)` (in case PC is set to 0xfff). 

1. Opcodes `FX33`, `FX55`, and `FX65` read from `memory[I + offset]`. A check exists to ensure `I` is not `>= sizeof(memory)`, but these opcodes could allow reading and writing outside of the valid memory range. Checks were added to them all to ensure the values read from memory are inside the valid space. 