### PR TITLE
gs_usb updates to fix python-can driver use (and bonus changes)

### DIFF
--- a/firmware/RAMNV1/Core/Inc/ramn_config.h
+++ b/firmware/RAMNV1/Core/Inc/ramn_config.h
@@ -50,15 +50,18 @@
 // - Error frames are not reported
 // - CAN-FD is not supported
 // - Due to clock differences, bit timings are not respected (but equivalent baudrates are used)
-// You may want to update USBD_VID and USBD_PID in usbd_desc.c to automatically load the drivers on Linux.
 // Try increasing _Min_Stack_Size if you run into issues
-// #define ENABLE_GSUSB
+//#define ENABLE_GSUSB
 
-#define USBD_VID                      	0x483
-#define USBD_PID                    	0x5740
-// IDs below can be used to automatically load the drivers on Linux
-//#define USBD_VID                      0x1d50
-//#define USBD_PID                      0x606f
+#ifndef ENABLE_GSUSB
+#define USBD_VID                        0x483
+#define USBD_PID                        0x5740
+#else
+// IDs below automatically load the drivers on Linux and are required for userspace python-can drivers
+#define USBD_VID                        0x1d50
+#define USBD_PID                        0x606f
+#endif
+
 #define USBD_LANGID_STRING            	1033
 #define USBD_MANUFACTURER_STRING      	"Toyota Motor Corporation"
 #define USBD_PRODUCT_STRING           	"RAMN USB Composite Device"

--- a/firmware/RAMNV1/Core/Src/main.c
+++ b/firmware/RAMNV1/Core/Src/main.c
@@ -37,6 +37,10 @@
 #include "ramn_cdc.h"
 #endif
 
+#ifdef ENABLE_GSUSB
+#include "ramn_gsusb.h"
+#endif
+
 #include "ramn_spi.h"
 #include "ramn_canfd.h"
 #include "ramn_trng.h"
@@ -1668,6 +1672,8 @@ void RAMN_ReceiveCANFunc(void *argument)
 #endif
 				}
 			}
+#endif
+
 #ifdef ENABLE_GSUSB
 			if(RAMN_USB_Config.gsusbOpened && GSUSB_IsConnected((USBD_HandleTypeDef*)hpcd_USB_FS.pData))
 			{
@@ -1677,8 +1683,6 @@ void RAMN_ReceiveCANFunc(void *argument)
 				}
 			}
 #endif
-#endif
-
 		}
 		else
 		{

--- a/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.c
+++ b/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.c
@@ -102,10 +102,10 @@ __ALIGN_BEGIN static uint8_t USBD_Composite_CfgFSDesc[] __ALIGN_END =
 	//---------------------------------------------------------------------------
 	0x07,                                 // bLength
 	USB_DESC_TYPE_ENDPOINT,               // bDescriptorType
-	GSUSB_IN_EP,                             // bEndpointAddress
+	GSUSB_IN_EP,                          // bEndpointAddress
 	0x02,                                 // bmAttributes: bulk
-	LOBYTE(CAN_DATA_MAX_PACKET_SIZE),     // wMaxPacketSize
-	HIBYTE(CAN_DATA_MAX_PACKET_SIZE),
+	LOBYTE(GSUSB_TX_DATA_SIZE),           // wMaxPacketSize
+	HIBYTE(GSUSB_TX_DATA_SIZE),
 	0x00,                                 // bInterval:
 	//---------------------------------------------------------------------------
 
@@ -114,10 +114,10 @@ __ALIGN_BEGIN static uint8_t USBD_Composite_CfgFSDesc[] __ALIGN_END =
 	//---------------------------------------------------------------------------
 	0x07,                                 // bLength
 	USB_DESC_TYPE_ENDPOINT,               // bDescriptorType
-	GSUSB_OUT_EP,                            // bEndpointAddress
+	GSUSB_OUT_EP,                         // bEndpointAddress
 	0x02,                                 // bmAttributes: bulk
-	LOBYTE(CAN_DATA_MAX_PACKET_SIZE),     // wMaxPacketSize
-	HIBYTE(CAN_DATA_MAX_PACKET_SIZE),
+	LOBYTE(GSUSB_RX_DATA_SIZE),           // wMaxPacketSize
+	HIBYTE(GSUSB_RX_DATA_SIZE),
 	0x00,                                 // bInterval:
 	//---------------------------------------------------------------------------
 
@@ -126,7 +126,7 @@ __ALIGN_BEGIN static uint8_t USBD_Composite_CfgFSDesc[] __ALIGN_END =
 	//---------------------------------------------------------------------------
 	0x09,                                 // bLength
 	USB_DESC_TYPE_INTERFACE,              // bDescriptorType
-	GSUSB_WINDEX + 1,                        // bInterfaceNumber
+	GSUSB_WINDEX + 1,                     // bInterfaceNumber
 	0x00,                                 // bAlternateSetting
 	0x00,                                 // bNumEndpoints
 	0xFE,                                 // bInterfaceClass: Vendor Specific
@@ -239,8 +239,8 @@ __ALIGN_BEGIN static uint8_t USBD_Composite_CfgFSDesc[] __ALIGN_END =
 	USB_DESC_TYPE_ENDPOINT,               // bDescriptorType: Endpoint
 	CDC_OUT_EP,                           // bEndpointAddress
 	0x02,                                 // bmAttributes: Bulk
-	LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  // wMaxPacketSize:
-	HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+	LOBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),  // wMaxPacketSize:
+	HIBYTE(CDC_DATA_FS_OUT_PACKET_SIZE),
 	0x00,                                 // bInterval: ignore for Bulk transfer
 
 	//---------------------------------------------------------------------------
@@ -250,8 +250,8 @@ __ALIGN_BEGIN static uint8_t USBD_Composite_CfgFSDesc[] __ALIGN_END =
 	USB_DESC_TYPE_ENDPOINT,               // bDescriptorType: Endpoint
 	CDC_IN_EP,                            // bEndpointAddress
 	0x02,                                 // bmAttributes: Bulk
-	LOBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),  // wMaxPacketSize:
-	HIBYTE(CDC_DATA_FS_MAX_PACKET_SIZE),
+	LOBYTE(CDC_DATA_FS_IN_PACKET_SIZE),   // wMaxPacketSize:
+	HIBYTE(CDC_DATA_FS_IN_PACKET_SIZE),
 	0x00,                                 // bInterval: ignore for Bulk transfer
 #endif
 

--- a/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.c
+++ b/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.c
@@ -791,7 +791,7 @@ uint8_t USBD_Composite_ReceivePacket(USBD_HandleTypeDef *pdev, uint32_t epnum)
 	{
 		buf = hcmp->RxBuffer[1];
 		/* Prepare Out endpoint to receive next packet */
-		(void)USBD_LL_PrepareReceive(pdev, epnum, buf, sizeof(struct gs_host_frame));
+		(void)USBD_LL_PrepareReceive(pdev, epnum, buf, GSUSB_RX_DATA_SIZE);
 	}
 
 	return (uint8_t)USBD_OK;

--- a/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.h
+++ b/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/usbd_composite.h
@@ -96,6 +96,8 @@ typedef struct
 extern USBD_ClassTypeDef USBD_Composite;
 #define USBD_CDC_CLASS &USBD_CDC
 
+#include "usbd_gsusb_if.h"
+
 uint8_t USBD_Composite_RegisterInterface(
 	USBD_HandleTypeDef  *pdev,
     void                *fops,

--- a/firmware/RAMNV1/RAMNV1 Debug.launch
+++ b/firmware/RAMNV1/RAMNV1 Debug.launch
@@ -46,7 +46,7 @@
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.cti_signal_halt" value="false"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.enable_logging" value="false"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.enable_max_halt_delay" value="false"/>
-    <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.enable_shared_stlink" value="false"/>
+    <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.enable_shared_stlink" value="true"/>
     <stringAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.frequency" value="0"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.halt_all_on_reset" value="false"/>
     <stringAttribute key="com.st.stm32cube.ide.mcu.debug.stlink.log_file" value="C:\Users\Ccamy\Desktop\EXPORTABLE\RAMN_GITHUB_REPO\RAMN\firmware\RAMNV1\Debug\st-link_gdbserver_log.txt"/>

--- a/firmware/RAMNV1/RAMNV1 Debug.launch
+++ b/firmware/RAMNV1/RAMNV1 Debug.launch
@@ -26,7 +26,7 @@
     <stringAttribute key="com.st.stm32cube.ide.mcu.debug.launch.swv_trace_hclk" value="80000000"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.launch.useRemoteTarget" value="true"/>
     <stringAttribute key="com.st.stm32cube.ide.mcu.debug.launch.vector_table" value=""/>
-    <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.launch.verify_flash_download" value="true"/>
+    <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.launch.verify_flash_download" value="false"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.openocd.CTI_ALLOW_HALT" value="false"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.openocd.CTI_SIGNAL_HALT" value="false"/>
     <booleanAttribute key="com.st.stm32cube.ide.mcu.debug.openocd.DBG_DEVICE_SHAREABLE_ALLOWED" value="false"/>

--- a/firmware/RAMNV1/USB_CompositeDevice/App/usbd_gsusb_if.h
+++ b/firmware/RAMNV1/USB_CompositeDevice/App/usbd_gsusb_if.h
@@ -35,8 +35,8 @@
 /* USER CODE BEGIN EXPORTED_DEFINES */
 /* Define size for the receive and transmit buffer over SocketCAN */
 /* It's up to user to redefine and/or remove those define */
-#define GSUSB_RX_DATA_SIZE  			1024
-#define GSUSB_TX_DATA_SIZE  			1024
+#define GSUSB_RX_DATA_SIZE  			128  // must be at least GS_HOST_FRAME_SIZE (80 bytes) to accommodate buggy userspace drivers
+#define GSUSB_TX_DATA_SIZE  			CAN_DATA_MAX_PACKET_SIZE  // must be at least CAN_DATA_MAX_PACKET_SIZE
 
  typedef struct _USBD_GSUSB_Itf
  {


### PR DESCRIPTION
The first two commits are the changes necessary to make this gs_usb implementation (when ENABLE_GSUSB) work with python-can cantact driver.
1. https://github.com/ToyotaInfoTech/RAMN/commit/325ec17d546c071de78d9eb19a874e31a19c7495
2. https://github.com/ToyotaInfoTech/RAMN/commit/f5246112fa90568a21673ac8843b8a2f8ee6b630

The next are changes
* to make USB descriptor reported sizes consistent with the send and receive sizes in the source code https://github.com/ToyotaInfoTech/RAMN/commit/fb037158a096f4b28b267f3b72ca43e09125feb8
* reduce gs_usb allocated buffers to the minimum required sizes https://github.com/ToyotaInfoTech/RAMN/commit/d5bf66582c27b8bbec00ef2d1f297738b5004d98
* reduce PMA buffer allocations to what is needed only https://github.com/ToyotaInfoTech/RAMN/commit/6e6e80c5c3824076d78961a893731a0b37b83c9f

Finally a couple bonus changes to the Debug Launch config.