### PR TITLE
usb: hold USB tx lock across ack + send

### DIFF
--- a/firmware/RAMNV1/Core/Inc/ramn_usb.h
+++ b/firmware/RAMNV1/Core/Inc/ramn_usb.h
@@ -62,6 +62,15 @@ void 			RAMN_USB_SendFromTask_Blocking(uint8_t* data, uint32_t length);
 // Sends Data over USB. Returns as soon as buffer is filled.
 RAMN_Result_t 	RAMN_USB_SendFromTask(const uint8_t* data, uint32_t length);
 
+// Acquires the USB TX lock. Must be paired with RAMN_USB_ReleaseLock.
+void 			RAMN_USB_AcquireLock(void);
+
+// Releases the USB TX lock previously acquired by RAMN_USB_AcquireLock.
+void 			RAMN_USB_ReleaseLock(void);
+
+// Sends Data over USB while the USB TX lock is already held by the caller.
+RAMN_Result_t 	RAMN_USB_SendFromTask_Locked(const uint8_t* data, uint32_t length);
+
 // Sends a string over serial USB
 RAMN_Result_t 	RAMN_USB_SendStringFromTask(const char* data);
 


### PR DESCRIPTION
`RAMN_ReceiveCANFunc` and `RAMN_ReceiveUSBFunc` both run at `osPriorityNormal` and write to the shared USB TX stream buffer via `USB_TX_SEMAPHORE`. When processing a transmit command, the `<CR>` and `RAMN_FDCAN_SendMessage` were not atomic—allowing the CAN RX task to forward a received frame between them, corrupting SLCAN framing on the host.

I caught a few instances of this while spying on the slcan serial port traffic on windows e.g.:

<img width="1314" height="680" alt="image" src="https://github.com/user-attachments/assets/40ee57b6-3256-4dfd-b9d6-b50fcf6522f7" />


### Fix

- Add `RAMN_USB_AcquireLock()` / `RAMN_USB_ReleaseLock()` / `RAMN_USB_SendFromTask_Locked()` to expose `USB_TX_SEMAPHORE` for multi-step atomic USB TX operations
- Hold the lock across the `<CR>` write and the first `RAMN_FDCAN_SendMessage` attempt in both standard and extended ID transmit paths
- Release before any retry loop to avoid starving CAN RX forwarding