### PR TITLE
Warnings: try harder

### DIFF
--- a/firmware/RAMNV1/.cproject
+++ b/firmware/RAMNV1/.cproject
@@ -70,6 +70,7 @@
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.1566503351" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.1815547934" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32L552CETX_FLASH.ld}" valueType="string"/>
+								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags.1815547935" name="Other flags" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags" value="-Wl,--no-warn-rwx-segments" valueType="string"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input.130960903" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
@@ -161,6 +162,7 @@
 							</tool>
 							<tool id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.62359485" name="MCU GCC Linker" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker">
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script.877762017" name="Linker Script (-T)" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.script" value="${workspace_loc:/${ProjName}/STM32L552CETX_FLASH.ld}" valueType="string"/>
+								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags.877762018" name="Other flags" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.option.otherflags" value="-Wl,--no-warn-rwx-segments" valueType="string"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input.1439787846" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.c.linker.input">
 									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
 									<additionalInput kind="additionalinput" paths="$(LIBS)"/>

--- a/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/CDC/usbd_cdc.c
+++ b/firmware/RAMNV1/Middlewares/ST/STM32_USB_Device_Library/USBClass/Composite/CDC/usbd_cdc.c
@@ -34,6 +34,7 @@
 *                            Public functions                                  *
 *==============================================================================*/
 
+#ifdef ENABLE_CDC
 static void cdc_init(USBD_HandleTypeDef *pdev, uint8_t index)
 {
 	if(index == 0)
@@ -61,6 +62,7 @@ static void cdc_init(USBD_HandleTypeDef *pdev, uint8_t index)
 		((USBD_Composite_HandleTypeDef *)pdev->pClassData)->RxState[0] = 0U;
 	}
 }
+#endif
 
 /**
   * @brief  USBD_CDC_Init

--- a/scripts/build/_build_ecu.sh
+++ b/scripts/build/_build_ecu.sh
@@ -9,10 +9,15 @@ shift 2 2>/dev/null || shift $#
 
 SKIP_IMPORT=false
 BUILD_MODE="-cleanBuild"
-for arg in "$@"; do
-	case "$arg" in
-		--skip-import) SKIP_IMPORT=true ;;
-		--no-clean) BUILD_MODE="-build" ;;
+EXTRA_DEFINES=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--skip-import) SKIP_IMPORT=true; shift ;;
+		--no-clean) BUILD_MODE="-build"; shift ;;
+		-D) EXTRA_DEFINES="${EXTRA_DEFINES} -D $2"; shift 2 ;;
+		-D*) EXTRA_DEFINES="${EXTRA_DEFINES} $1"; shift ;;
+		*) shift ;;
 	esac
 done
 
@@ -32,4 +37,4 @@ fi
 # when the Docker container's clock differs from the host that created the files.
 find "${WORKSPACE}" -type f -exec touch -c {} + 2>/dev/null || true
 
-headless-build.sh -data /tmp/stm-workspace ${BUILD_MODE} ${PROJECT_NAME}/${PROJECT_CONF} -D ${ECU}
+headless-build.sh -data /tmp/stm-workspace ${BUILD_MODE} ${PROJECT_NAME}/${PROJECT_CONF} -D ${ECU} ${EXTRA_DEFINES}


### PR DESCRIPTION
the remaining RWX warning is a false positive for STM32 I think. It seems that the .cproject fix is incompatible with older toolchains. So we either a) live with the 1 RWX warning or b) drop 7.0 tag (1.10 version) toolchains. I am proposing B but happy to swap to A if you prefer. 

One other warning left was regarding cdc_init when no ENABLE_CDC (found with the coverage matrix).