### PR TITLE
ship also GSUSB RAMN firmware

### DIFF
--- a/.github/generate_report.py
+++ b/.github/generate_report.py
@@ -23,7 +23,7 @@ import sys
 
 
 def parse_hex_sizes(metrics_dir):
-    """Return {(conf, tag): {ecu: size_str}} from build-metrics artifacts."""
+    """Return {(conf, tag, variant): {ecu: size_str}} from build-metrics artifacts."""
     sizes = {}
     if not os.path.isdir(metrics_dir):
         return sizes
@@ -32,15 +32,22 @@ def parse_hex_sizes(metrics_dir):
         txt = os.path.join(d, "hex-sizes.txt")
         if not os.path.isfile(txt):
             continue
-        # directory name like build-metrics-RAMNV1-Release-15.0
+        # directory name like build-metrics-RAMNV1-<variant>-<conf>-<tag>
+        # or legacy build-metrics-RAMNV1-<conf>-<tag>
         if not entry.startswith("build-metrics-"):
             continue
         parts = entry.split("-")
-        if len(parts) < 5:
+        if len(parts) >= 6:
+            tag = parts[-1]
+            conf = parts[-2]
+            variant = parts[-3]
+        elif len(parts) >= 5:
+            tag = parts[-1]
+            conf = parts[-2]
+            variant = "default"
+        else:
             continue
-        tag = parts[-1]
-        conf = parts[-2]
-        key = (conf, tag)
+        key = (conf, tag, variant)
         sizes.setdefault(key, {})
         with open(txt) as f:
             for line in f:
@@ -69,7 +76,11 @@ def hex_size_table(sizes):
     if not configs:
         return "| ECU | Release | Debug |\n|-----|---------|-------|\n"
 
-    headers = ["ECU"] + [f"{conf} (tag {tag})" for conf, tag in configs]
+    def col_header(conf, tag, variant):
+        label = conf if variant == "default" else f"{conf} ({variant})"
+        return f"{label} (tag {tag})"
+
+    headers = ["ECU"] + [col_header(conf, tag, variant) for conf, tag, variant in configs]
     lines = ["| " + " | ".join(headers) + " |"]
     lines.append("|" + "|".join(["-----"] * len(headers)) + "|")
     for ecu in ("ECUA", "ECUB", "ECUC", "ECUD"):

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build_all:
-    name: ${{ matrix.conf }} (tag ${{ matrix.cubeide_docker_tag }})
+    name: ${{ matrix.variant == 'default' && matrix.conf || format('{0} ({1})', matrix.conf, matrix.variant) }} (tag ${{ matrix.cubeide_docker_tag }})
     permissions:
       contents: read
     strategy:
@@ -20,12 +20,21 @@ jobs:
       matrix:
         spice: [RAMNV1]
         conf: [Release, Debug]
-        cubeide_docker_tag: ["7.0", "15.0"]
+        cubeide_docker_tag: ["15.0"]
+        variant: [default, gsusb]
 
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: Modify ramn_config.h for ${{ matrix.variant }}
+        if: matrix.variant == 'gsusb'
+        run: |
+          python3 .github/modify_config.py \
+            --ecu TARGET_ECUA \
+            --variant "${{ matrix.variant }}" \
+            --enable "ENABLE_GSUSB"
 
       - name: Build all ECUs (${{ matrix.conf }})
         env:
@@ -51,14 +60,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: build-metrics-${{ matrix.spice }}-${{ matrix.conf }}-${{ matrix.cubeide_docker_tag }}
+          name: build-metrics-${{ matrix.spice }}-${{ matrix.variant }}-${{ matrix.conf }}-${{ matrix.cubeide_docker_tag }}
           path: build-metrics/
 
       - name: upload RAMN dir as artifact
         if: ${{ !env.ACT }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.spice }}-${{ matrix.conf }}-${{ matrix.cubeide_docker_tag }}
+          name: ${{ matrix.spice }}-${{ matrix.variant }}-${{ matrix.conf }}-${{ matrix.cubeide_docker_tag }}
           path: .
 
   macro_coverage:

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ hardware/V1_revC/0_ramn/fp-info-cache
 firmware/RAMNV1/Core/Inc/ramn_screen_template.h
 firmware/RAMNV1/Core/Src/ramn_screen_template.c
 firmware/RAMNV1/RAMNV1 Debug.launch
+workspace/
+__pycache__/


### PR DESCRIPTION
Add gsusb variant to build_all matrix (for main branch builds / releases)

* gsusb variants keep usb serial enabled
* includes adding backward compatibility for legacy artifact name format in report parser