### PR TITLE
firmware: restore joystick decoding in non-J1939 mode

### DIFF
--- a/firmware/RAMNV1/Core/Inc/ramn_can_database.h
+++ b/firmware/RAMNV1/Core/Inc/ramn_can_database.h
@@ -29,6 +29,7 @@ uint8_t RAMN_Decode_Command_Shift(const uint8_t* payload, uint32_t dlc);
 
 void RAMN_Encode_Control_Shift_Joystick(uint8_t shift_value, uint8_t joystick_value, uint8_t* payload);
 uint8_t RAMN_Decode_Control_Shift(const uint8_t* payload, uint32_t dlc);
+uint8_t RAMN_Decode_Joystick(const uint8_t* payload, uint32_t dlc);
 
 void RAMN_Encode_JoystickButtons(uint8_t joystick_state, uint8_t* payload);
 uint8_t RAMN_Decode_JoystickButtons(const uint8_t* payload, uint32_t dlc);

--- a/firmware/RAMNV1/Core/Src/ramn_dbc.c
+++ b/firmware/RAMNV1/Core/Src/ramn_dbc.c
@@ -202,8 +202,15 @@ void RAMN_DBC_ProcessCANMessage(uint32_t canid, uint32_t dlc, RAMN_CANFrameData_
 			break;
 		case CAN_SIM_CONTROL_SHIFT_CANID:
 			RAMN_DBC_Handle.control_shift = RAMN_Decode_Control_Shift(&dataframe->rawData[CAN_SIM_CONTROL_SHIFT_PAYLOAD_OFFSET / 8], dlc);
+			if (dlc >= 2U)
+			{
+				RAMN_DBC_Handle.joystick = RAMN_Decode_Joystick(&dataframe->rawData[CAN_SIM_CONTROL_SHIFT_PAYLOAD_OFFSET / 8], dlc);
+				#ifdef ENABLE_JOYSTICK_CONTROLS
+					RAMN_Joystick_Update(RAMN_DBC_Handle.joystick);
+				#endif
+			}
 			break;
-#ifdef ENABLE_J1939_MODE
+#ifdef CAN_SIM_JOYSTICK_BUTTONS_CANID
 		case CAN_SIM_JOYSTICK_BUTTONS_CANID:
 			RAMN_DBC_Handle.joystick = RAMN_Decode_JoystickButtons(&dataframe->rawData[CAN_SIM_JOYSTICK_BUTTONS_PAYLOAD_OFFSET / 8], dlc);
 			#ifdef ENABLE_JOYSTICK_CONTROLS

--- a/scripts/tests/mocks/main.h
+++ b/scripts/tests/mocks/main.h
@@ -123,9 +123,27 @@ uint8_t DLCtoUINT8(uint32_t dlc);
 uint32_t UINT8toDLC(uint8_t size);
 
 // External modules dependencies
-typedef struct {
-    float status_rpm;
-    uint8_t control_lights;
+typedef volatile struct
+{
+	volatile uint16_t control_brake; 			//CANID_CONTROL_BRAKE
+	volatile uint16_t command_brake; 			//CANID_COMMAND_BRAKE
+	volatile uint16_t control_accel; 			//CANID_CONTROL_ACCEL
+	volatile uint16_t command_accel; 			//CANID_COMMAND_ACCEL
+	volatile uint16_t control_steer; 			//CANID_CONTROL_STEERING
+	volatile uint16_t command_steer; 			//CANID_COMMAND_STEERING
+	volatile uint8_t  control_shift;			//CANID_CONTROL_SHIFT
+	volatile uint16_t command_shift;			//CANID_COMMAND_SHIFT
+	volatile uint16_t control_sidebrake; 		//CANID_CONTROL_SIDEBRAKE
+	volatile uint16_t command_sidebrake; 		//CANID_COMMAND_SIDEBRAKE
+	volatile uint16_t status_rpm; 				//CANID_STATUS_RPM
+	volatile uint8_t command_horn;				//CANID_COMMAND_HORN
+	volatile uint8_t control_horn; 				//CANID_CONTROL_HORN
+	volatile uint16_t command_lights; 			//CANID_COMMAND_LIGHTS
+	volatile uint16_t command_turnindicator;	//CANID_COMMAND_TURNINDICATOR
+	volatile uint16_t control_enginekey;		//CANID_CONTROL_ENGINEKEY
+	volatile uint16_t control_lights; 			//CANID_CONTROL_LIGHTS
+	volatile uint8_t joystick;					// Second byte of SHIFT, saved for convenience
+
 } RAMN_DBC_Handle_t;
 extern RAMN_DBC_Handle_t RAMN_DBC_Handle;
 extern uint8_t RAMN_DBC_RequestSilence;
@@ -198,8 +216,9 @@ typedef struct { uint32_t Instance; } TIM_HandleTypeDef;
        ((uint32_t)(sa) & 0xFF))
 
 // DBC Frame Data mock
-typedef struct {
-    uint8_t dummy;
+typedef union
+{
+	uint8_t rawData[8];
 } RAMN_CANFrameData_t;
 
 // Missing prototypes for Diag


### PR DESCRIPTION
Restore joystick decoding in standard CAN mode by re-adding the decoding call in CAN_SIM_CONTROL_SHIFT_CANID case. Also fixed a misplaced J1939 guard that was preventing JOYSTICK_BUTTONS from being received even if sent.