### PR TITLE
Fix USB serial corruption under bidirectional CDC load

### DIFF
--- a/firmware/RAMNV1/Core/Src/ramn_usb.c
+++ b/firmware/RAMNV1/Core/Src/ramn_usb.c
@@ -65,32 +65,41 @@ void RAMN_USB_Init(StreamBufferHandle_t* buffer,  osThreadId_t* pSendTask)
 
 void RAMN_USB_SendFromTask_Blocking(uint8_t* data, uint32_t length)
 {
-	// Start sending
-	if(CDC_Transmit_FS((uint8_t*)data,length) != USBD_OK)
+	// Zero-copy IN transfer: the DMA reads directly from 'data', so we must not return until the
+	// hardware is done. Poll the real endpoint state (RAMN_CDC_GetTXStatus); the Cplt notification is
+	// only a wake-up. The notification counts, so trusting it as the buffer-free signal can desync by one (e.g. a ZLP) and overwrite the buffer mid-DMA.
+
+	// Drop any stale token so the wait below pairs with this transfer only.
+	(void)ulTaskNotifyTake(pdTRUE, 0U);
+
+	if (CDC_Transmit_FS((uint8_t*)data, length) != USBD_OK)
 	{
-		// Should not Happen if serial is still opened
-#ifdef ENABLE_USB_AUTODETECT
-		if (RAMN_USB_Config.serialOpened == True)
-		{
-			RAMN_USB_Config.USBTxOverflowCnt++;
-			RAMN_USB_Config.serialOpened = False;
-		}
-#else
+		// Transfer did not start, so 'data' is already free to reuse.
 		RAMN_USB_Config.USBTxOverflowCnt++;
-#endif
+		return;
 	}
-	if (ulTaskNotifyTake(pdTRUE, USB_TX_TIMEOUT_MS) == 0U)
+
+	// Block until the IN endpoint is idle, bounded by USB_TX_TIMEOUT_MS.
+	uint32_t waited = 0U;
+	while (RAMN_CDC_GetTXStatus() != USBD_OK)
 	{
-		// Timeout Occurred, report if serial port is still opened
+		(void)ulTaskNotifyTake(pdTRUE, 1U);   // sleep on Cplt notify or 1 tick, then re-poll TxState
 #ifdef ENABLE_USB_AUTODETECT
-		if (RAMN_USB_Config.serialOpened == True)
+		// Port closed mid-transfer: the close callback clears serialOpened and wakes us. The transfer
+		// never completes, so abort now instead of waiting out the full timeout.
+		if (RAMN_USB_Config.serialOpened == False)
 		{
-			RAMN_USB_Config.USBErrCnt++;
-			RAMN_USB_Config.serialOpened = False;
+			RAMN_CDC_AbortTx();
+			break;
 		}
-#else
-		RAMN_USB_Config.USBErrCnt++;
 #endif
+		if (++waited >= USB_TX_TIMEOUT_MS)
+		{
+			// Stuck transfer: abort so the buffer can be reused safely.
+			RAMN_USB_Config.USBErrCnt++;
+			RAMN_CDC_AbortTx();
+			break;
+		}
 	}
 }
 
@@ -101,13 +110,17 @@ RAMN_Result_t RAMN_USB_SendFromTask(const uint8_t* data, uint32_t length)
 
 	while (xSemaphoreTake(USB_TX_SEMAPHORE, portMAX_DELAY ) != pdTRUE);
 
-	xBytesSent = xStreamBufferSend(*usbTxBuffer, data, length, 2000U);
+	// Frame-atomic: only enqueue if the whole frame fits, else drop it to keep the SLCAN stream
+	// frame-aligned. Single writer (mutex held) + consumer only frees space, so the send writes in full.
+	if (xStreamBufferSpacesAvailable(*usbTxBuffer) >= length)
+	{
+		xBytesSent = xStreamBufferSend(*usbTxBuffer, data, length, 0U);
+	}
 	xSemaphoreGive(USB_TX_SEMAPHORE);
 	if (xBytesSent != length)
 	{
 		RAMN_USB_Config.USBTxOverflowCnt++;
 		result = RAMN_ERROR;
-		while( xStreamBufferReset(*usbTxBuffer) != pdPASS) osDelay(10); //Clear buffer
 	}
 
 	return result;
@@ -128,12 +141,15 @@ RAMN_Result_t RAMN_USB_SendFromTask_Locked(const uint8_t* data, uint32_t length)
 	size_t xBytesSent = 0;
 	RAMN_Result_t result = RAMN_OK;
 
-	xBytesSent = xStreamBufferSend(*usbTxBuffer, data, length, 2000U);
+	// Caller already holds USB_TX_SEMAPHORE. Frame-atomic: see RAMN_USB_SendFromTask.
+	if (xStreamBufferSpacesAvailable(*usbTxBuffer) >= length)
+	{
+		xBytesSent = xStreamBufferSend(*usbTxBuffer, data, length, 0U);
+	}
 	if (xBytesSent != length)
 	{
 		RAMN_USB_Config.USBTxOverflowCnt++;
 		result = RAMN_ERROR;
-		while( xStreamBufferReset(*usbTxBuffer) != pdPASS) osDelay(10); //Clear buffer
 	}
 
 	return result;

--- a/firmware/RAMNV1/USB_CompositeDevice/App/usbd_cdc_if.c
+++ b/firmware/RAMNV1/USB_CompositeDevice/App/usbd_cdc_if.c
@@ -152,6 +152,18 @@ uint8_t RAMN_CDC_GetTXStatus()
 		return USBD_OK;
 	}
 }
+
+// Abort a stuck CDC IN transfer: flush the endpoint FIFO and mark the channel idle so the shared
+// zero-copy TX buffer can be reused. Called only on the hard timeout in RAMN_USB_SendFromTask_Blocking.
+void RAMN_CDC_AbortTx(void)
+{
+	USBD_Composite_HandleTypeDef *hcdc = (USBD_Composite_HandleTypeDef*)hUsbDeviceFS.pClassData;
+	(void)USBD_LL_FlushEP(&hUsbDeviceFS, CDC_IN_EP);
+	if (hcdc != NULL)
+	{
+		hcdc->TxState[0] = 0U;
+	}
+}
 /* USER CODE END PRIVATE_FUNCTIONS_DECLARATION */
 
 /**
@@ -331,24 +343,17 @@ static int8_t CDC_Receive_FS(uint8_t* Buf, uint32_t *Len)
 				{
 					if(USBD_recvBuffer != NULL)
 					{
-						if (xStreamBufferSendFromISR(*USBD_recvBuffer, &currentIndex, 2U, NULL ) != 2U)
+						// Frame-atomic: only enqueue if both the 2-byte length prefix and the body fit, else drop the whole command
+						if (xStreamBufferSpacesAvailable(*USBD_recvBuffer) < (2U + (size_t)currentIndex))
 						{
-							//If a callback function has been registered, report issue
-							//if (USBD_errorCallback_ptr != NULL) (*USBD_errorCallback_ptr)(&hUsbDeviceFS);
 							RAMN_USB_Config.USBErrCnt++;
 						}
 						else
 						{
-							if (xStreamBufferSendFromISR(*USBD_recvBuffer, recvBuf, currentIndex, NULL ) != currentIndex)
-							{
-								//if (USBD_errorCallback_ptr != NULL) (*USBD_errorCallback_ptr)(&hUsbDeviceFS);
-								RAMN_USB_Config.USBErrCnt++;
-							}
-							else
-							{
-								vTaskNotifyGiveFromISR(*USBD_recvTask, &xHigherPriorityTaskWoken);
-								portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-							}
+							xStreamBufferSendFromISR(*USBD_recvBuffer, &currentIndex, 2U, NULL );
+							xStreamBufferSendFromISR(*USBD_recvBuffer, recvBuf, currentIndex, NULL );
+							vTaskNotifyGiveFromISR(*USBD_recvTask, &xHigherPriorityTaskWoken);
+							portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 						}
 					}
 				}

--- a/firmware/RAMNV1/USB_CompositeDevice/App/usbd_cdc_if.h
+++ b/firmware/RAMNV1/USB_CompositeDevice/App/usbd_cdc_if.h
@@ -130,6 +130,9 @@ void RAMN_CDC_Init(StreamBufferHandle_t* pBuffer, osThreadId_t* pRecvTask, osThr
 
 //Returns current transmit Status of USB module
 uint8_t RAMN_CDC_GetTXStatus();
+
+//Aborts a stuck CDC IN transfer (flush EP + mark idle) so the shared TX buffer can be reused safely
+void RAMN_CDC_AbortTx(void);
 /* USER CODE END EXPORTED_FUNCTIONS */
 
 /**

--- a/firmware/RAMNV1/USB_CompositeDevice/Target/usbd_conf.c
+++ b/firmware/RAMNV1/USB_CompositeDevice/Target/usbd_conf.c
@@ -409,23 +409,24 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 	/* USER CODE BEGIN EndPoint_Configuration */
 
-	epaddr = hpcd_USB_FS.Init.dev_endpoints * 16 / 2; // 16 bytes BDT per endpoint, and convert to half-words
+	// On the STM32L5 (unlike F1/F3) USB IP the PMA is byte-addressed (PMA_ACCESS == 1), not word-addressed.
+	epaddr = hpcd_USB_FS.Init.dev_endpoints * 16 / 2; // BTABLE: 8 bytes per endpoint
 
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x00 ,        PCD_SNG_BUF, epaddr);
-	epaddr += USB_MAX_EP0_SIZE / 2;
+	epaddr += USB_MAX_EP0_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , 0x80 ,        PCD_SNG_BUF, epaddr);
-	epaddr += USB_MAX_EP0_SIZE / 2;
+	epaddr += USB_MAX_EP0_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , CDC_IN_EP  ,  PCD_SNG_BUF, epaddr);
-	epaddr += CDC_DATA_FS_IN_PACKET_SIZE / 2;
+	epaddr += CDC_DATA_FS_IN_PACKET_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , CDC_OUT_EP ,  PCD_SNG_BUF, epaddr);
-	epaddr += CDC_DATA_FS_OUT_PACKET_SIZE / 2;
+	epaddr += CDC_DATA_FS_OUT_PACKET_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , CDC_CMD_EP ,  PCD_SNG_BUF, epaddr);
-	epaddr += CDC_CMD_PACKET_SIZE / 2;
+	epaddr += CDC_CMD_PACKET_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , GSUSB_IN_EP , PCD_SNG_BUF, epaddr);
-	epaddr += GSUSB_TX_DATA_SIZE / 2;
+	epaddr += GSUSB_TX_DATA_SIZE;
 	HAL_PCDEx_PMAConfig((PCD_HandleTypeDef*)pdev->pData , GSUSB_OUT_EP, PCD_SNG_BUF, epaddr);
-	epaddr += GSUSB_RX_DATA_SIZE / 2;
-	if(epaddr > 320) {
+	epaddr += GSUSB_RX_DATA_SIZE;
+	if(epaddr > 1024) {   // STM32L5 USB PMA is 1024 bytes
 		USBD_ErrLog("PMA buffers too big")
 	}
 	/* USER CODE END EndPoint_Configuration_CDC */


### PR DESCRIPTION
I noticed some corruption bugs under heavy traffic load.
Some analysis with Claude revealed that the root cause is wrong memory addressing for DMA (current code assumes it is word-indexed, but it is byte-indexed) - this can result in RX buffer and TX buffer overlapping.
Copy-pasting Claude's suggestions below.

----------

1. PMA buffer overlap (root cause), usbd_conf.c: on the STM32L5 the packet memory is byte-addressed (PMA_ACCESS == 1), so each endpoint must advance by its full packet size. The code advanced by PACKET_SIZE/2 (a leftover from word-indexed F1/F3 PMA), under-allocating every endpoint and making CDC_IN and CDC_OUT overlap by 32 bytes. Under full-duplex load the two directions overwrote each other's PMA. Advance by the full packet size and raise the size guard to the real PMA capacity (1024).

2. Zero-copy TX buffer reuse, ramn_usb.c: the blocking send treated a counting FreeRTOS task notification as the buffer-free signal, which can desync and let the consumer overwrite the buffer mid-DMA. Wait on the real endpoint state (RAMN_CDC_GetTXStatus) instead, use the notification only as a wake-up, drain stale tokens before transmitting, and abort a stuck transfer on timeout (new RAMN_CDC_AbortTx helper). Under ENABLE_USB_AUTODETECT, also break promptly when the close callback clears serialOpened.

Frame-atomic stream-buffer writes (TX and the OUT-ISR receive path) now drop a whole frame on overflow instead of partial-writing, keeping the SLCAN framing aligned.