### PR TITLE
fix: Command_TurnIndicator default-mode encoding is swapped vs the project's DBC

### DIFF
--- a/firmware/RAMNV1/Core/Src/ramn_can_database.c
+++ b/firmware/RAMNV1/Core/Src/ramn_can_database.c
@@ -160,14 +160,16 @@ uint16_t RAMN_Decode_Control_Horn_Default(const uint8_t* payload, uint32_t dlc) 
 }
 
 void RAMN_Encode_Command_TurnIndicator_Default(uint16_t value, uint8_t* payload) {
-    uint16_t packed = PACK_SIGNAL(value, COMMAND_TURNINDICATOR_MASK, COMMAND_TURNINDICATOR_OFFSET);
-    RAMN_memcpy(payload, (uint8_t*)&packed, sizeof(packed));
+    /* Bypass PACK_SIGNAL: with USE_BIG_ENDIAN_CAN it byte-swaps any 0xFFFF-masked signal, which is
+     * wrong here since Left/Right are two independent flag bytes (high byte = Left, low byte =
+     * Right), not one 16-bit value. Same fix pattern as RAMN_Encode_Command_Lights_Default. */
+    payload[0] = (uint8_t)(value & 0xFF);
+    payload[1] = (uint8_t)((value >> 8) & 0xFF);
 }
 uint16_t RAMN_Decode_Command_TurnIndicator_Default(const uint8_t* payload, uint32_t dlc) {
-    uint16_t packed = 0;
-    RAMN_memcpy((uint8_t*)&packed, payload, sizeof(packed));
-    if (dlc <= 1U) packed = packed & 0xFF;
-    return UNPACK_SIGNAL(packed, COMMAND_TURNINDICATOR_MASK, COMMAND_TURNINDICATOR_OFFSET);
+    uint16_t result = (uint16_t)payload[0];
+    if (dlc >= 2U) result |= ((uint16_t)payload[1] << 8);
+    return result;
 }
 
 void RAMN_Encode_Command_Sidebrake_Default(uint16_t value, uint8_t* payload) {

--- a/firmware/RAMNV1/Core/Src/ramn_can_database.c
+++ b/firmware/RAMNV1/Core/Src/ramn_can_database.c
@@ -160,9 +160,6 @@ uint16_t RAMN_Decode_Control_Horn_Default(const uint8_t* payload, uint32_t dlc) 
 }
 
 void RAMN_Encode_Command_TurnIndicator_Default(uint16_t value, uint8_t* payload) {
-    /* Bypass PACK_SIGNAL: with USE_BIG_ENDIAN_CAN it byte-swaps any 0xFFFF-masked signal, which is
-     * wrong here since Left/Right are two independent flag bytes (high byte = Left, low byte =
-     * Right), not one 16-bit value. Same fix pattern as RAMN_Encode_Command_Lights_Default. */
     payload[0] = (uint8_t)(value & 0xFF);
     payload[1] = (uint8_t)((value >> 8) & 0xFF);
 }

--- a/scripts/tests/test_turnindicator_encoding.py
+++ b/scripts/tests/test_turnindicator_encoding.py
@@ -1,0 +1,101 @@
+"""
+Test that non-J1939 Command_TurnIndicator encoding matches the DBC definition:
+
+    BO_ 423 TurnIndicators: 8 Vector__XXX
+     SG_ Left : 8|1@0- (1,0) [0|1] "" Vector__XXX
+     SG_ Right : 0|1@0- (1,0) [0|1] "" Vector__XXX
+
+Per the DBC, Right lives in byte 0 and Left lives in byte 1. RAMN's internal
+convention (see RAMN_Encode_Command_TurnIndicator_J1939) is that the high
+byte of the 16-bit signal value means Left and the low byte means Right, so
+byte 0 of the payload must carry the low byte (Right) and byte 1 must carry
+the high byte (Left), with no byte-swap.
+
+This test builds the non-J1939 shared library with USE_BIG_ENDIAN_CAN
+defined (matching the firmware configuration in ramn_config.h) to reproduce
+the on-target byte layout.
+"""
+
+import ctypes
+import os
+import subprocess
+import pytest
+
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+LIB_PATH = os.path.join(os.path.dirname(__file__), "librbd_can_db_bigendian_turnindicator.so")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def build_bigendian_lib():
+    """Build the non-J1939 shared library with USE_BIG_ENDIAN_CAN defined.
+
+    This matches the firmware configuration (ramn_config.h defines
+    USE_BIG_ENDIAN_CAN) to reproduce the on-target byte layout.
+    """
+    includes = "-I scripts/tests/mocks/ -I firmware/RAMNV1/Core/Inc/"
+    cflags = "-shared -fPIC -DCPYTHON_TESTING -D__MAIN_H -DUSE_BIG_ENDIAN_CAN"
+    src = "firmware/RAMNV1/Core/Src/ramn_can_database.c"
+    cmd = f"gcc {cflags} {includes} -o {LIB_PATH} {src}"
+    result = subprocess.run(
+        cmd, shell=True, cwd=REPO_ROOT, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to build bigendian lib:\n{result.stderr}")
+
+
+@pytest.fixture(scope="module")
+def lib():
+    """Load the big-endian non-J1939 shared library."""
+    ramn_lib = ctypes.CDLL(LIB_PATH)
+    ramn_lib.RAMN_Encode_Command_TurnIndicator_Default.argtypes = [
+        ctypes.c_uint16,
+        ctypes.POINTER(ctypes.c_uint8),
+    ]
+    ramn_lib.RAMN_Encode_Command_TurnIndicator_Default.restype = None
+    ramn_lib.RAMN_Decode_Command_TurnIndicator_Default.argtypes = [
+        ctypes.POINTER(ctypes.c_uint8),
+        ctypes.c_uint32,
+    ]
+    ramn_lib.RAMN_Decode_Command_TurnIndicator_Default.restype = ctypes.c_uint16
+    return ramn_lib
+
+
+@pytest.mark.parametrize(
+    "value, expect_byte0_nonzero, expect_byte1_nonzero, label",
+    [
+        (0x00FF, True, False, "Right_only"),
+        (0xFF00, False, True, "Left_only"),
+        (0x0000, False, False, "none"),
+    ],
+)
+def test_turnindicator_bytes_match_dbc_layout(
+    lib, value, expect_byte0_nonzero, expect_byte1_nonzero, label
+):
+    """
+    Per busmaster_ramn.dbc, CAN ID 0x1A7 (TurnIndicators) has Right at bit 0
+    of byte 0 and Left at bit 0 of byte 1. RAMN's internal value convention
+    puts Right in the low byte (0x00FF) and Left in the high byte (0xFF00),
+    so encoding must place the low byte in payload[0] and the high byte in
+    payload[1] -- unswapped.
+    """
+    buf = (ctypes.c_uint8 * 8)(*([0] * 8))
+    lib.RAMN_Encode_Command_TurnIndicator_Default(ctypes.c_uint16(value), buf)
+
+    assert (buf[0] != 0) == expect_byte0_nonzero, (
+        f"[{label}] byte[0]=0x{buf[0]:02X}: Right (byte 0 per DBC) does not "
+        f"match expectation for internal value 0x{value:04X}"
+    )
+    assert (buf[1] != 0) == expect_byte1_nonzero, (
+        f"[{label}] byte[1]=0x{buf[1]:02X}: Left (byte 1 per DBC) does not "
+        f"match expectation for internal value 0x{value:04X}"
+    )
+
+
+@pytest.mark.parametrize("value", [0x0000, 0x00FF, 0xFF00, 0x0101, 0x1234, 0xFFFF])
+def test_turnindicator_roundtrip(lib, value):
+    buf = (ctypes.c_uint8 * 8)(*([0] * 8))
+    lib.RAMN_Encode_Command_TurnIndicator_Default(ctypes.c_uint16(value), buf)
+    decoded = lib.RAMN_Decode_Command_TurnIndicator_Default(buf, ctypes.c_uint32(8))
+    assert decoded == value, f"Roundtrip failed for value 0x{value:04X}: got 0x{decoded:04X}"


### PR DESCRIPTION
Command_TurnIndicator's non-J1939 (default) encode/decode goes through the shared `PACK_SIGNAL`/`UNPACK_SIGNAL` macros, and under `USE_BIG_ENDIAN_CAN` (unconditionally on in `ramn_config.h`) those macros byte-swap any signal masked with `0xFFFF`. That's the right thing to do for a genuine 16-bit value like brake/accel/steering, but `COMMAND_TURNINDICATOR_MASK` is also `0xFFFF` even though the value isn't really one 16-bit number -- it's two independent 1-bit flags, high byte for Left and low byte for Right (that's the convention `RAMN_Encode_Command_TurnIndicator_J1939` already uses and comments on).

I checked this against `misc/busmaster_ramn.dbc` with cantools: CAN ID 0x1A7 (TurnIndicators) has `Right` at byte 0 bit 0 and `Left` at byte 1 bit 0. Because of the swap, encoding "Left only" in default mode actually puts the bit in byte 0 and clears byte 1, so anything decoding the frame against the project's own DBC reads it as Right active / Left inactive -- backwards. Since RAMN's own encode and decode use the same swapped convention, this is invisible from RAMN's own software (it round-trips fine internally) and only shows up once you decode real traffic against the published DBC, which is exactly what this testbed is for.

This is the same bug class as the Command_Lights fix from a few weeks ago (`RAMN_Encode_Command_Lights_Default` / #55) -- I used the same fix: write the two bytes directly instead of going through the macro, so nothing gets swapped.

I built `ramn_can_database.c` with `-DUSE_BIG_ENDIAN_CAN` (matching the real firmware config) into a small shared lib and drove it with ctypes: before the fix, encoding "Left only" produced wire bytes that cantools decodes against the DBC as Right=1/Left=0; after the fix it decodes as Left=1/Right=0 as intended, same for the Right-only case. Encode/decode roundtrip still holds across the full uint16 range. Added `scripts/tests/test_turnindicator_encoding.py`, same shape as the existing lighting-switch test, checking the byte placement and the roundtrip.
