### PR TITLE
Fix broken Linux ECU A flashing script (dfu-util + .hex)

### DIFF
--- a/scripts/STbootloader/linux/ProgramECU_A.sh
+++ b/scripts/STbootloader/linux/ProgramECU_A.sh
@@ -1,5 +1,6 @@
 ECU_FIRMWARE_PATH=../../firmware
 
-dfu-util -d 0x0483:0xdf11 -c1 -a0 -D "$ECU_FIRMWARE_PATH/ECUA.hex" -R
+objcopy -I ihex -O binary "$ECU_FIRMWARE_PATH/ECUA.hex" /tmp/ECUA.bin
+dfu-util -d 0x0483:0xdf11 -c1 -a0 -D /tmp/ECUA.bin --dfuse-address 0x08000000:leave
 
 sleep 10


### PR DESCRIPTION
## Problem
`scripts/STbootloader/linux/ProgramECU_A.sh` currently fails on every
run with:

    dfu-util: Only DfuSe file version 1.1a is supported
    dfu-util: (for raw binary download, use the --dfuse-address option)

This regressed in e34ad5f, which switched the script to pass `ECUA.hex`
straight to dfu-util (dropping `--dfuse-address`) and removed the
`ECUA.bin` the previous, working version relied on. dfu-util has never
been able to parse Intel HEX for DfuSe devices — it needs either a raw
binary + `--dfuse-address`, or a `.dfu`-wrapped file.

## Fix
Convert `ECUA.hex` to a raw binary with `objcopy` at flash time, then
pass `--dfuse-address 0x08000000:leave` as before e34ad5f. This avoids
re-adding a binary artifact to the repo and keeps `.hex` as the single
source of truth, matching the Windows script (`STM32_Programmer_CLI`)
which reads `.hex` natively via its own parser.

## Testing
Verified end-to-end on a fresh (never-flashed) RAMN board:
- Fedora 42 KDE, dfu-util 0.11
- Board enumerates as `0483:df11` in DFU mode
- Script now flashes successfully and board re-enumerates as a CDC
  serial device afterwards
- `ProgramECU_BCD.sh` then completes normally

Closes #67 